### PR TITLE
Add GitHub repo link to dashboard view

### DIFF
--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -2,8 +2,10 @@
   <h2>Dashboard</h2>
   <% @repos.each do |repo| %>
   <p class="dashboard-row">
-    <input type="checkbox" class="btn-switch" data-repoid="<%= repo['id'] %>" data-slug="<%= "#{repo['owner_name']}/#{repo['name']}" %>" <% if repo['enabled'] %>checked="checked"<% end %>>
-    <span class="dashboard-slug"><%= repo['owner_name'] %>/<%= repo['name'] %></span>
+    <% repo_slug = "#{repo['owner_name']}/#{repo['name']}" %>
+    <input type="checkbox" class="btn-switch" data-repoid="<%= repo['id'] %>" data-slug="<%= repo_slug %>" <% if repo['enabled'] %>checked="checked"<% end %>>
+    <span class="dashboard-slug"><%= repo_slug %></span>
+    <a href=<%= "https://github.com/#{repo_slug}" %>><span class="glyphicon glyphicon-link"></span></a>
     <span class="dashboard-description"><%= repo['description'] %></span>
   </p>
   <% end %>


### PR DESCRIPTION
The actual GH url doesn't seemt o come back in the `repo` payload.
Manually constructing the URL and passing creating a link icon seemed to
be a simple way to acheive this.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

Looks like:

<img width="569" alt="screenshot 2017-02-24 08 54 45" src="https://cloud.githubusercontent.com/assets/529516/23306273/c3f4c1e6-fa70-11e6-9405-ee1e617f1c5f.png">
